### PR TITLE
Add NiFi API trigger script

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,32 @@
+const NIFI_API_URL = 'http://localhost:8080/nifi-api';
+
+/**
+ * Trigger a NiFi processor to run once.
+ * @param {string} processorId - The UUID of the processor to run.
+ */
+async function triggerFlow(processorId) {
+  try {
+    const response = await fetch(`${NIFI_API_URL}/processors/${processorId}/run-status`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        revision: { version: 0 },
+        state: 'RUN_ONCE'
+      })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`NiFi response ${response.status}: ${text}`);
+    }
+
+    alert('Flux déclenché avec succès');
+  } catch (error) {
+    console.error('Erreur lors du déclenchement du flux:', error);
+    alert(`Erreur: ${error.message}`);
+  }
+}
+// Expose the function globally so it can be used by inline HTML handlers
+window.triggerFlow = triggerFlow;


### PR DESCRIPTION
## Summary
- Add client-side script to trigger NiFi processors via REST API

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f8631c2883329ba34c65b1ea3680