### PR TITLE
Handle NiFi revision before triggering run

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             <button onclick="triggerFlow('85416964-f171-348c-6487-8ba2a2da0bea')">Entrée stock implant qualité</button>
             <button onclick="triggerFlow('536287e6-7412-397a-9426-5fd159bf1820')">Entrée stock</button>
             <button onclick="triggerFlow('040fad0e-851d-3d48-16d1-08cfbce7b147')">Stock secu V1</button>
-            <button onclick="triggerFlow('ID_DU_PROCESSOR_1')">Stock secu brut<br><span class="ButtonSpan">(Erreur execution SQL)</span></button>
+            <button onclick="triggerFlow('eef1d394-10eb-3de1-f4a3-0b9b148178e5')">Stock secu brut<br><span class="ButtonSpan">(Erreur execution SQL)</span></button>
             <button onclick="triggerFlow('450812b9-1429-39bd-cacd-29373865c640')">Reste à livrer</button><br>
             <button onclick="triggerFlow('01c87c40-84ff-3698-35c1-66bdd69f1fab')">Transfert Fab ➜ stock</button>
         </div>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
-const NIFI_API_URL = 'http://localhost:8080/nifi-api';
+// URL de base de l'API NiFi déployée sur srv-etl-01 en HTTPS
+const NIFI_API_URL = 'https://srv-etl-01:8443/nifi-api';
 
 /**
  * Trigger a NiFi processor to run once.
@@ -6,13 +7,24 @@ const NIFI_API_URL = 'http://localhost:8080/nifi-api';
  */
 async function triggerFlow(processorId) {
   try {
+    // NiFi exige de fournir la révision courante du processeur pour
+    // modifier son état. On récupère donc la révision actuelle avant
+    // de demander l'exécution.
+    const infoResp = await fetch(`${NIFI_API_URL}/processors/${processorId}`);
+    if (!infoResp.ok) {
+      const text = await infoResp.text();
+      throw new Error(`Impossible de récupérer la révision : ${infoResp.status} ${text}`);
+    }
+
+    const processor = await infoResp.json();
+
     const response = await fetch(`${NIFI_API_URL}/processors/${processorId}/run-status`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        revision: { version: 0 },
+        revision: processor.revision,
         state: 'RUN_ONCE'
       })
     });


### PR DESCRIPTION
## Summary
- Fetch current NiFi processor revision before requesting a run-once state
- Point the NiFi API base URL to the secure srv-etl-01 endpoint
- Trigger "Stock secu brut" with processor eef1d394-10eb-3de1-f4a3-0b9b148178e5

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6fcefe5b88332a29a7fe888d443f9