### PR TITLE
Handle NiFi revision before triggering run

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             <button onclick="triggerFlow('85416964-f171-348c-6487-8ba2a2da0bea')">Entrée stock implant qualité</button>
             <button onclick="triggerFlow('536287e6-7412-397a-9426-5fd159bf1820')">Entrée stock</button>
             <button onclick="triggerFlow('040fad0e-851d-3d48-16d1-08cfbce7b147')">Stock secu V1</button>
-            <button onclick="triggerFlow('ID_DU_PROCESSOR_1')">Stock secu brut<br><span class="ButtonSpan">(Erreur execution SQL)</span></button>
+            <button onclick="triggerFlow('eef1d394-10eb-3de1-f4a3-0b9b148178e5')">Stock secu brut<br><span class="ButtonSpan">(Erreur execution SQL)</span></button>
             <button onclick="triggerFlow('450812b9-1429-39bd-cacd-29373865c640')">Reste à livrer</button><br>
             <button onclick="triggerFlow('01c87c40-84ff-3698-35c1-66bdd69f1fab')">Transfert Fab ➜ stock</button>
         </div>


### PR DESCRIPTION
## Summary
- Fetch current NiFi processor revision before requesting a run-once state
- Point the NiFi API base URL to the secure srv-etl-01 endpoint
- Trigger "Stock secu brut" with processor eef1d394-10eb-3de1-f4a3-0b9b148178e5
- Expose run-once helper for both browser and Node.js, falling back to console when `alert` is unavailable

## Testing
- `npm test`
- `node -e "const {triggerFlow}=require('./script.js'); triggerFlow('eef1d394-10eb-3de1-f4a3-0b9b148178e5').catch(e=>console.error(e));"` *(fails: getaddrinfo ENOTFOUND srv-etl-01)*
- `curl -k https://srv-etl-01:8443/nifi-api/` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fcefe5b88332a29a7fe888d443f9