### PR TITLE
feat: handle NiFi token authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,15 @@
   <link rel="stylesheet" href="./style.css">
   <link rel="icon" type="image/png" href="./logoPetitSF.png">
 </head>
-<body>
+  <body>
     <img id="logo" src="../logo.png" alt="logo">
     <img id="slogan" src="./slogan.png" alt="slogan">
+
+    <div id="auth">
+      <input type="text" id="username" placeholder="Utilisateur">
+      <input type="password" id="password" placeholder="Mot de passe">
+      <button onclick="login()">Se connecter</button>
+    </div>
 
     <div class="section">
         <h2 class="titre-anim">Mouvement des stocks</h2>

--- a/script.js
+++ b/script.js
@@ -1,16 +1,67 @@
 // URL de base de l'API NiFi déployée sur srv-etl-01 en HTTPS
 const NIFI_API_URL = 'https://srv-etl-01:8443/nifi-api';
 
+// Jeton d'authentification obtenu depuis NiFi
+let authToken = null;
+
+/**
+ * Authentifie l'utilisateur auprès de NiFi et stocke le jeton.
+ */
+async function login() {
+  try {
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const params = new URLSearchParams();
+    params.append('username', username);
+    params.append('password', password);
+
+    const resp = await fetch(`${NIFI_API_URL}/access/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params,
+      mode: 'cors'
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Échec authentification : ${resp.status} ${text}`);
+    }
+
+    authToken = await resp.text();
+    if (typeof alert !== 'undefined') {
+      alert('Authentification réussie');
+    } else {
+      console.log('Authentification réussie');
+    }
+  } catch (error) {
+    console.error('Erreur authentification:', error);
+    if (typeof alert !== 'undefined') {
+      alert(`Erreur: ${error.message}`);
+    }
+  }
+}
+
 /**
  * Trigger a NiFi processor to run once.
  * @param {string} processorId - The UUID of the processor to run.
  */
 async function triggerFlow(processorId) {
   try {
+    if (!authToken) {
+      throw new Error('Veuillez vous authentifier d\'abord');
+    }
+
     // NiFi exige de fournir la révision courante du processeur pour
     // modifier son état. On récupère donc la révision actuelle avant
     // de demander l'exécution.
-    const infoResp = await fetch(`${NIFI_API_URL}/processors/${processorId}`);
+    const infoResp = await fetch(`${NIFI_API_URL}/processors/${processorId}`, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      },
+      mode: 'cors'
+    });
     if (!infoResp.ok) {
       const text = await infoResp.text();
       throw new Error(`Impossible de récupérer la révision : ${infoResp.status} ${text}`);
@@ -21,12 +72,14 @@ async function triggerFlow(processorId) {
     const response = await fetch(`${NIFI_API_URL}/processors/${processorId}/run-status`, {
       method: 'PUT',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
       },
       body: JSON.stringify({
         revision: processor.revision,
         state: 'RUN_ONCE'
-      })
+      }),
+      mode: 'cors'
     });
 
     if (!response.ok) {
@@ -49,7 +102,8 @@ async function triggerFlow(processorId) {
 // Expose the function for both browser and Node.js contexts
 if (typeof window !== 'undefined') {
   window.triggerFlow = triggerFlow;
+  window.login = login;
 }
 if (typeof module !== 'undefined') {
-  module.exports = { triggerFlow };
+  module.exports = { triggerFlow, login };
 }


### PR DESCRIPTION
## Summary
- add login UI and token retrieval for NiFi API
- include bearer token on processor trigger requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b70368af9c833283dfaf149486b891